### PR TITLE
aacrawfi/v1.0-alias

### DIFF
--- a/content/zh-hans/developing-applications/building-blocks/actors/actors-overview.md
+++ b/content/zh-hans/developing-applications/building-blocks/actors/actors-overview.md
@@ -4,8 +4,6 @@ title: "Dapr Actors 概述"
 linkTitle: "Secrets stores overview"
 weight: 10
 description: Dapr Actor 构建块概述
-aliases:
-  - "/developing-applications/building-blocks/actors/actors-background"
 ---
 
 ## 介绍

--- a/content/zh-hans/developing-applications/sdks/sdk-serialization.md
+++ b/content/zh-hans/developing-applications/sdks/sdk-serialization.md
@@ -4,8 +4,6 @@ title: "Dapr SDK中的序列化"
 linkTitle: "序列化（Serialization）"
 description: "Dapr如何在SDK中序列化数据"
 weight: 2000
-aliases:
-  - '/developing-applications/sdks/serialization/'
 ---
 
 Dapr的SDK为下面两种情况提供序列化： 首先是对于通过请求和响应的有效载荷传递的API对象。 其次，对于要持久化的对象。 对于这两种情况，SDK都提供了默认的序列化实现。 在Java SDK中，由[DefaultObjectSerializer](https://dapr.github.io/java-sdk/io/dapr/serializer/DefaultObjectSerializer.html)这个类提供JSON序列化功能。

--- a/content/zh-hans/getting-started/configure-state-pubsub.md
+++ b/content/zh-hans/getting-started/configure-state-pubsub.md
@@ -4,8 +4,6 @@ title: "如何操作：配置 状态存储 和 发布/订阅 消息代理"
 linkTitle: "(可选) 配置 状态 & 发布/订阅"
 weight: 400
 description: "配置Dapr的状态存储和 发布/订阅 消息代理"
-aliases:
-  - /getting-started/configure-redis/
 ---
 
 为了启动和运行状态和 发布/订阅 构建块，需要两个组件。

--- a/content/zh-hans/getting-started/install-dapr-selfhost.md
+++ b/content/zh-hans/getting-started/install-dapr-selfhost.md
@@ -3,8 +3,6 @@ type: docs
 title: "在本地环境中初始化 Dapr"
 linkTitle: "本地初始化 Dapr"
 weight: 20
-aliases:
-  - /getting-started/install-dapr/
 ---
 
 现在，您已经安装了 [Dapr CLI]({{X22X}})，是时候使用 CLI 在本地机器上初始化 Dapr 了。

--- a/content/zh-hans/operations/components/setup-pubsub/supported-pubsub/setup-gcp-pubsub.md
+++ b/content/zh-hans/operations/components/setup-pubsub/supported-pubsub/setup-gcp-pubsub.md
@@ -3,8 +3,6 @@ type: docs
 title: "GCP Pub/Sub"
 linkTitle: "GCP Pub/Sub"
 description: "GCP Pub/Sub组件详细文档"
-aliases:
-  - "/operations/components/setup-pubsub/supported-pubsub/setup-gcp/"
 ---
 
 ## 创建 Dapr 组件

--- a/content/zh-hans/operations/hosting/kubernetes/kubernetes-deploy.md
+++ b/content/zh-hans/operations/hosting/kubernetes/kubernetes-deploy.md
@@ -4,8 +4,6 @@ title: "在Kubernetes集群上部署Dapr"
 linkTitle: "Deploy Dapr"
 weight: 20000
 description: "按照这些步骤在Kubernetes上部署Dapr"
-aliases:
-  - /getting-started/install-dapr-kubernetes/
 ---
 
 你可以使用 Dapr CLI 或 Helm 在 Kubernetes 中部署 Dapr


### PR DESCRIPTION
Remove aliases in docs to fix bug where links direct to ZH translation instead of english